### PR TITLE
chore: sync config files from .config-templates

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-This code of conduct outlines expectations for behavior when participating in the chebpy project with the aim of fostering a constructive and professional engineering environment.
+This code of conduct outlines expectations for behavior when participating in the project with the aim of fostering a constructive and professional engineering environment.
 
 ## Expected Behavior
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,7 @@ and all tests pass.
 ## Building from source
 
 You'll need to build the project locally in order to start editing code.
-To install from source, clone the Github
+To install from source, clone the GitHub
 repository, navigate to its root, and run the following command:
 
 ```bash
@@ -29,7 +29,7 @@ make install
 ## Contributing code
 
 To contribute to the project, send us pull requests.
-For those new to contributing, check out Github's
+For those new to contributing, check out GitHub's
 [guide](https://help.github.com/articles/using-pull-requests/).
 
 Once you've made your pull request, a member of the
@@ -44,7 +44,7 @@ please
 fix your code and send another commit, which will re-trigger the tests.
 
 If you'd like to add a new feature, please do propose your
-change on a Github issue, to make sure
+change on a GitHub issue, to make sure
 that your priorities align with ours.
 
 If you'd like to contribute code but don't know where to start,

--- a/.github/taskfiles/cleanup.yml
+++ b/.github/taskfiles/cleanup.yml
@@ -4,10 +4,13 @@ tasks:
   clean:
     desc: Clean generated files and directories
     cmds:
-      - printf " ${BLUE}[INFO] Cleaning project...${RESET}\n"
-      - git clean -d -X -f
-      - rm -rf dist build *.egg-info .coverage .pytest_cache
-      - printf " ${BLUE}[INFO] Removing local branches with no remote counterpart...${RESET}\n"
-      - git fetch -p
       - |
-        git branch -vv | grep ': gone]' | awk '{print $$1}' | xargs -r git branch -D
+        printf " ${BLUE}[INFO] Cleaning project...${RESET}\n"
+        git clean -d -X -f
+        rm -rf dist build *.egg-info .coverage .pytest_cache
+        printf " ${BLUE}[INFO] Removing local branches with no remote counterpart...${RESET}\n"
+        git fetch --prune
+        git branch -vv \
+          | grep ': gone]' \
+          | awk '{print $1}' \
+          | xargs -r git branch -D 2>/dev/null || true

--- a/.github/taskfiles/docs.yml
+++ b/.github/taskfiles/docs.yml
@@ -30,9 +30,13 @@ tasks:
       - |
         if [ -f "pyproject.toml" ]; then
           printf "${BLUE}[INFO] Building documentation...${RESET}\n"
-          SOURCE_FOLDER=src/$(find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | head -1)
-          uv pip install pdoc
-          uv run pdoc -o _pdoc "$SOURCE_FOLDER"
+          if [ -d "src" ]; then
+            SOURCE_FOLDER=$(LC_ALL=C find src -mindepth 1 -maxdepth 1 -type d -not -path '*/\.*' | sort | head -1)
+            uv pip install pdoc
+            uv run pdoc -o _pdoc "$SOURCE_FOLDER"
+          else
+            printf "${YELLOW}[WARN] No src/ directory found, skipping docs${RESET}\n"
+          fi
         else
           printf "${YELLOW}[WARN] No pyproject.toml found, skipping docs${RESET}\n"
         fi
@@ -47,7 +51,7 @@ tasks:
           printf "${YELLOW}[WARN] Directory '{{.MARIMO_FOLDER}}' does not exist. Skipping marimushka.${RESET}\n"
         else
           mkdir -p _marimushka
-          py_files=$(find "{{.MARIMO_FOLDER}}" -name "*.py" | tr '\n' ' ')
+          py_files=$(find "{{.MARIMO_FOLDER}}" -maxdepth 1 -name "*.py" | tr '\n' ' ')
           if [ -z "$py_files" ]; then
             printf "${YELLOW}[WARN] No Python files found in '{{.MARIMO_FOLDER}}'.${RESET}\n"
             echo "<html><head><title>Marimo Notebooks</title></head><body><h1>Marimo Notebooks</h1><p>No notebooks found.</p></body></html>" > _marimushka/index.html

--- a/.github/workflows/marimo.yml
+++ b/.github/workflows/marimo.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 
 on:
-  push
+  - push
 
 jobs:
   # Parse .env file and build a matrix of notebooks to test
@@ -31,11 +31,11 @@ jobs:
           fi
           
           # Find notebooks and handle empty results
-          if [ -z "$(find "$NOTEBOOK_DIR" -name "*.py" 2>/dev/null)" ]; then
+          if [ -z "$(find "$NOTEBOOK_DIR" -maxdepth 1 -name "*.py" 2>/dev/null)" ]; then
             echo "No notebooks found in $NOTEBOOK_DIR. Setting empty matrix."
             echo "matrix=[]" >> "$GITHUB_OUTPUT"
           else
-            notebooks=$(find "$NOTEBOOK_DIR" -name "*.py" -print0 | xargs -0 -n1 echo | jq -R -s -c 'split("\n")[:-1]')
+            notebooks=$(find "$NOTEBOOK_DIR" -maxdepth 1 -name "*.py" -print0 | xargs -0 -n1 echo | jq -R -s -c 'split("\n")[:-1]')
             echo "matrix=$notebooks" >> "$GITHUB_OUTPUT"
           fi
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ _book
 _tests
 _marimushka
 
+# temp file used by Junie
+.output.txt
+
+# .env file for configuration, e.g. OpenBB
+.env
+
 quantstats.md
 
 # Byte-compiled / optimized / DLL files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-yaml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.12.8'
+    rev: 'v0.12.9'
     hooks:
       - id: ruff
         args: [ --fix, --exit-non-zero-on-fix, --unsafe-fixes ]

--- a/ruff.toml
+++ b/ruff.toml
@@ -6,6 +6,9 @@ line-length = 120
 # Target Python version
 target-version = "py312"
 
+# Exclude directories with Jinja template variables in their names
+exclude = ["**/[{][{]*", "**/*[}][}]*"]
+
 [lint]
 # Available rule sets in Ruff:
 # A: flake8-builtins - Check for python builtins being used as variables or parameters

--- a/tests/test_taskfile.py
+++ b/tests/test_taskfile.py
@@ -4,13 +4,67 @@ This module contains tests that verify all tasks defined in Taskfile.yml
 work correctly and produce the expected output.
 """
 
+import dataclasses
 import os
 import shutil
 import subprocess
 import tempfile
 from pathlib import Path
+from subprocess import CompletedProcess
 
 import pytest
+
+
+@dataclasses.dataclass
+class Result:
+    """Class for storing the result of a task."""
+
+    result: CompletedProcess
+
+    @property
+    def stdout(self):
+        """Get the standard output of the process.
+
+        Returns:
+            The standard output as a string, decoded if necessary
+        """
+        stdout = self.result.stdout
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", errors="replace")
+
+        return stdout
+
+    @property
+    def stderr(self):
+        """Get the standard error of the process.
+
+        Returns:
+            The standard error output
+        """
+        stderr = self.result.stderr
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", errors="replace")
+        return stderr
+
+    @property
+    def returncode(self):
+        """Get the return code of the process.
+
+        Returns:
+            The process return code
+        """
+        return self.result.returncode
+
+    def contains_message(self, message: str) -> bool:
+        """Check if a message is in stdout.
+
+        Args:
+            message: The message to check for
+
+        Returns:
+            True if the message is in stdout, False otherwise
+        """
+        return message in self.stdout
 
 
 class TestTaskfile:
@@ -150,48 +204,43 @@ class TestTaskfile:
             timeout: Maximum time to wait for task completion
 
         Returns:
-            CompletedProcess instance
+            Result instance containing the process result
         """
         # Get the appropriate task name with group prefix if needed
         task_name = self.get_task_name(task_name)
 
         try:
-            result = subprocess.run(
-                f"task {task_name}", shell=True, capture_output=True, text=True, check=check, timeout=timeout
+            result = Result(
+                result=subprocess.run(
+                    f"task {task_name}", shell=True, capture_output=True, text=True, check=check, timeout=timeout
+                )
             )
             return result
         except subprocess.TimeoutExpired as e:
             # For tasks that might hang (like servers)
-            return subprocess.CompletedProcess(
+            completed_process = subprocess.CompletedProcess(
                 args=e.cmd,
                 returncode=0,  # Assume it's working if it's still running
                 stdout=e.stdout if e.stdout else "Task is still running (timeout)",
                 stderr=e.stderr if e.stderr else "",
             )
+            return Result(result=completed_process)
 
     def test_default_task(self):
         """Test that the default task runs and displays help."""
         result = self.run_task("")
         assert result.returncode == 0, f"Default task failed with: {result.stderr}"
-        assert "Available tasks" in result.stdout, "Help information not displayed"
+        assert result.contains_message("Available tasks"), "Help information not displayed"
         # Check that it lists at least some common tasks
-        assert "* docs:book:" in result.stdout or "* book:" in result.stdout, "Book task not listed"
-        assert "* docs:test:" in result.stdout or "* test:" in result.stdout, "Test task not listed"
+        assert result.contains_message("* docs:book:") or result.contains_message("* book:"), "Book task not listed"
+        assert result.contains_message("* docs:test:") or result.contains_message("* test:"), "Test task not listed"
 
     def test_help_task(self):
         """Test that the help task runs and displays help."""
         # The help task should run 'task --list-all'
         result = self.run_task("help")
         assert result.returncode == 0, f"Help task failed with: {result.stderr}"
-        assert "Available tasks" in result.stdout, "Help information not displayed"
-
-    @pytest.mark.skip(reason="Potentially modifies system, only run manually")
-    def test_uv_task(self):
-        """Test that the uv task installs uv and uvx."""
-        result = self.run_task("build:uv", check=False)
-        assert result.returncode == 0 or "uv installation completed" in result.stdout, (
-            f"UV task failed: {result.stderr}"
-        )
+        assert result.contains_message("Available tasks"), "Help information not displayed"
 
     def test_install_task(self):
         """Test that the install task creates a virtual environment."""
@@ -205,8 +254,8 @@ class TestTaskfile:
 
         # Check for expected output - either it's creating a new environment
         # or it's skipping because one already exists (in the test environment)
-        assert any(
-            msg in result.stdout for msg in ["Creating virtual environment...", "Virtual environment already exists"]
+        assert result.contains_message("Creating virtual environment...") or result.contains_message(
+            "Virtual environment already exists"
         ), f"Unexpected output: {result.stdout}"
 
         # The second part of the test is problematic because the task might detect
@@ -238,7 +287,7 @@ class TestTaskfile:
             "Virtual environment already exists",
             "Installing dependencies",
         ]
-        assert any(msg in result.stdout for msg in expected_msgs), (
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
             f"Expected build or install message not found in output: {result.stdout}"
         )
 
@@ -246,19 +295,21 @@ class TestTaskfile:
         os.remove("pyproject.toml")
         result = self.run_task("build", check=False)
         expected_msgs = ["No pyproject.toml found", "skipping build"]
-        assert any(msg in result.stdout for msg in expected_msgs), (
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
             f"Should warn about missing pyproject.toml: {result.stdout}"
         )
 
     def test_fmt_task(self):
         """Test that the fmt task runs formatters."""
         result = self.run_task("fmt", check=False)
-        assert "Running formatters..." in result.stdout, f"Formatter message not found in output: {result.stdout}"
+        assert result.contains_message("Running formatters..."), (
+            f"Formatter message not found in output: {result.stdout}"
+        )
 
     def test_lint_task(self):
         """Test that the lint task runs linters."""
         result = self.run_task("lint", check=False)
-        assert "Running linters..." in result.stdout, f"Linter message not found in output: {result.stdout}"
+        assert result.contains_message("Running linters..."), f"Linter message not found in output: {result.stdout}"
 
     def test_deptry_task(self):
         """Test that the deptry task checks dependencies."""
@@ -266,12 +317,14 @@ class TestTaskfile:
         self.create_pyproject_toml()
 
         result = self.run_task("deptry", check=False)
-        assert "Running deptry..." in result.stdout, f"Deptry message not found in output: {result.stdout}"
+        assert result.contains_message("Running deptry..."), f"Deptry message not found in output: {result.stdout}"
 
         # Test without pyproject.toml
         os.remove("pyproject.toml")
         result = self.run_task("deptry", check=False)
-        assert "No pyproject.toml found" in result.stdout, f"Should warn about missing pyproject.toml: {result.stdout}"
+        assert result.contains_message("No pyproject.toml found"), (
+            f"Should warn about missing pyproject.toml: {result.stdout}"
+        )
 
     def test_check_task(self):
         """Test that the check task runs all checks."""
@@ -286,7 +339,7 @@ class TestTaskfile:
             "Running deptry",
             "No pyproject.toml found",
         ]
-        assert result.returncode == 0 or any(msg in result.stdout for msg in expected_msgs), (
+        assert result.returncode == 0 or any(result.contains_message(msg) for msg in expected_msgs), (
             f"Check task failed: {result.stderr}"
         )
 
@@ -296,13 +349,13 @@ class TestTaskfile:
         self.create_tests_structure()
 
         result = self.run_task("docs:test", check=False)
-        assert "Running tests..." in result.stdout, f"Test message not found in output: {result.stdout}"
+        assert result.contains_message("Running tests..."), f"Test message not found in output: {result.stdout}"
 
         # Test with no source folder
         result = self.run_task("docs:test", check=False)
-        assert "No valid source folder structure found" in result.stdout or "Running tests..." in result.stdout, (
-            f"Unexpected output: {result.stdout}"
-        )
+        assert result.contains_message("No valid source folder structure found") or result.contains_message(
+            "Running tests..."
+        ), f"Unexpected output: {result.stdout}"
 
     def test_docs_task(self):
         """Test that the docs task builds documentation."""
@@ -319,7 +372,7 @@ class TestTaskfile:
             "Virtual environment already exists",
             "Installing dependencies",
         ]
-        assert any(msg in result.stdout for msg in expected_msgs), (
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
             f"Expected docs or install message not found in output: {result.stdout}"
         )
 
@@ -327,20 +380,24 @@ class TestTaskfile:
         os.remove("pyproject.toml")
         result = self.run_task("docs", check=False)
         expected_msgs = ["No pyproject.toml found", "skipping docs"]
-        assert any(msg in result.stdout for msg in expected_msgs), (
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
             f"Should warn about missing pyproject.toml: {result.stdout}"
         )
 
     def test_marimushka_task(self):
         """Test that the marimushka task exports notebooks."""
         result = self.run_task("marimushka", check=False)
-        assert "Exporting notebooks from" in result.stdout, f"Marimushka message not found in output: {result.stdout}"
+        assert result.contains_message("Exporting notebooks from"), (
+            f"Marimushka message not found in output: {result.stdout}"
+        )
 
         # Create marimo directory and test file
         self.create_marimo_structure()
 
         result = self.run_task("marimushka", check=False)
-        assert "Exporting notebooks from" in result.stdout, f"Marimushka message not found in output: {result.stdout}"
+        assert result.contains_message("Exporting notebooks from"), (
+            f"Marimushka message not found in output: {result.stdout}"
+        )
 
     def test_book_task(self):
         """Test that the book task builds the companion book."""
@@ -362,7 +419,7 @@ class TestTaskfile:
             "Virtual environment already exists",
             "Installing dependencies",
         ]
-        assert any(msg in result.stdout for msg in expected_msgs), (
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
             f"Expected book-related message not found in output: {result.stdout}"
         )
 
@@ -374,13 +431,10 @@ class TestTaskfile:
         # Use a very short timeout to avoid actually starting the server
         result = self.run_task("marimo", check=False, timeout=1)
 
-        # Check for marimo-related messages, ensuring we handle both string and bytes output
-        stdout = result.stdout
-        if isinstance(stdout, bytes):
-            stdout = stdout.decode("utf-8", errors="replace")
-
         expected_msgs = ["Start Marimo server with", "Marimo folder", "Installing dependencies"]
-        assert any(msg in stdout for msg in expected_msgs), f"Marimo server message not found in output: {stdout}"
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Marimo server message not found in output: {result.stdout}"
+        )
 
     def test_clean_task(self):
         """Test that the clean task cleans the project."""
@@ -395,7 +449,9 @@ class TestTaskfile:
 
         # The task might actually clean files or just show the message
         expected_msgs = ["Cleaning project...", "git clean", "Removing local branches..."]
-        assert any(msg in result.stdout for msg in expected_msgs), f"Clean message not found in output: {result.stdout}"
+        assert any(result.contains_message(msg) for msg in expected_msgs), (
+            f"Clean message not found in output: {result.stdout}"
+        )
 
     def test_all_tasks_defined(self):
         """Test that all tasks defined in Taskfile.yml are tested."""


### PR DESCRIPTION
This PR updates config files from [tschm/.config-templates](https://github.com/tschm/.config-templates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Clarified Code of Conduct wording and corrected GitHub capitalization in contributing guide.
- Chores
  - Improved local branch cleanup reliability and safety.
  - Docs task now skips gracefully when no src directory; limits marimo file discovery to top-level.
  - Workflow narrows notebook discovery to top-level only.
  - Added .output.txt and .env to .gitignore.
  - Updated Ruff pre-commit hook version and excluded Jinja-like paths from linting.
- Tests
  - Introduced a Result wrapper for subprocess outputs and updated tests to use it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->