### PR TITLE
Remove versioning from __init__.py

### DIFF
--- a/src/minibook/__init__.py
+++ b/src/minibook/__init__.py
@@ -3,10 +3,6 @@
 Generates a clean, responsive HTML webpage using Jinja2 templates.
 """
 
-import importlib.metadata
-
 from .main import entrypoint, generate_html
-
-__version__ = importlib.metadata.version("minibook")
 
 __all__ = ["entrypoint", "generate_html"]


### PR DESCRIPTION
Removed version retrieval from importlib.metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed version information from the minibook package exports. Users relying on accessing version details through the package should use an alternative method.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->